### PR TITLE
Add maven central to CI for release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,3 @@ jobs:
         with:
           name: JARs
           path: links-detektor/build/libs/*.jar
-
-# TODO: Add automation for auto artifactory push

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Execute tests
         run: "./gradlew test"
 
+      - name: Release to Maven central
+        run: "./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication"
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,6 +49,11 @@ jobs:
 
       - name: Release to Maven central
         run: "./gradlew publishAllPublicationsToProjectLocalRepository zipMavenCentralPortalPublication releaseMavenCentralPortalPublication"
+        env:
+          maven-central-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          maven-central-password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          signing-key: ${{ secrets.SIGNING_KEY }}
+          signing-password: ${{ secrets.SIGNING_PASSWORD }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -2,9 +2,6 @@ name: Qodana
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-lib = "2.0.2-alpha02" # Links Detektor library version
+lib = "2.0.3" # Links Detektor library version
 
 detekt = "1.23.8"  # Note: Plugin versions must be updated in the settings.gradle.kts too
 kotlin = "2.2.0"  # Note: Plugin versions must be updated in the settings.gradle.kts too

--- a/links-detektor/build.gradle.kts
+++ b/links-detektor/build.gradle.kts
@@ -177,10 +177,7 @@ publishing {
 
 
 signing {
-    val signingKey = System.getenv("SIGNING_KEY") ?: project.findProperty("signingKey") as String?
-    val signingPassword = System.getenv("SIGNING_PASSWORD") ?: project.findProperty("signingPassword") as String?
-
-    if (signingKey != null && signingPassword != null) {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-    }
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a CI step to automate publishing artifacts to Maven Central and bump the Detektor library version to 2.0.3 for release.

Build:
- Bump Detektor library version from 2.0.2-alpha02 to 2.0.3 in libs.versions.toml.

CI:
- Add CI step in GitHub Actions to publish all publications to Maven Central.